### PR TITLE
Add tests and example for enhanced RateControl

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -2,15 +2,15 @@
 
 This directory contains simple usage examples for **fspin**. Each example demonstrates using `RateControl` either via the `@spin` decorator or by directly creating the class. Both synchronous and asynchronous approaches are shown.
 
-| File                 | Description                                                             |
-|----------------------|-------------------------------------------------------------------------|
-| `sync_decorator.py`  | Run a synchronous function at a fixed rate using the `@spin` decorator. |
-| `sync_manual.py`     | Use `rate` directly with a synchronous function.                        |
-| `async_decorator.py` | Run an asynchronous coroutine with the decorator.                       |
-| `async_manual.py`    | Use `rate` directly with an async coroutine.                            |
-| `loop_in_place.py`   | Use context managet `with loop(...):`.                                  |
+| File                   | Description                                                 |
+|------------------------|-------------------------------------------------------------|
+| `sync_decorator.py`    | Run a synchronous function at a fixed rate using the `@spin` decorator. |
+| `sync_manual.py`       | Use `rate` directly with a synchronous function.            |
+| `async_decorator.py`   | Run an asynchronous coroutine with the decorator.           |
+| `async_manual.py`      | Use `rate` directly with an async coroutine.                |
+| `loop_in_place.py`     | Use context managet `with loop(...):`.                      |
+| `dynamic_frequency.py` | Change the loop frequency at runtime.                       |
 
 Run any example with `python <file>` to see the behaviour.
 
-Note that the scripts modify `sys.path` so they work when executed directly from
-this repository without installation.
+Note that the scripts modify `sys.path` so they work when executed directly from this repository without installation.

--- a/example/dynamic_frequency.py
+++ b/example/dynamic_frequency.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from fspin import rate
+
+
+def tick():
+    print(f"tick at {time.strftime('%H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    rc = rate(freq=2, is_coroutine=False, report=True, thread=True)
+    rc.start_spinning(tick, None)
+    time.sleep(2)
+    print("\nChanging frequency to 4 Hz\n")
+    rc.frequency = 4
+    time.sleep(2)
+    rc.stop_spinning()
+    rc.get_report()


### PR DESCRIPTION
## Summary
- add tests for exception tracking, dynamic frequency changes, and __str__/__repr__
- update existing histogram and report tests for new API
- provide an example demonstrating changing frequency on the fly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f219dc7fc832c89a58feb6a6eaf97