### PR TITLE
Add GitHub repository links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     author=PACKAGE_AUTHOR,
+    url="https://github.com/Suke0811/fspin",
+    project_urls={
+        "Source": "https://github.com/Suke0811/fspin",
+        "Tracker": "https://github.com/Suke0811/fspin/issues",
+    },
     license='MIT',
     packages=find_packages(include=[PACKAGE_NAME, PACKAGE_NAME + '.*']),
     install_requires=requirements,


### PR DESCRIPTION
## Summary
- include `url` and `project_urls` in `setup.py` so PyPI links back to GitHub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f38fc8438832cbc0578cea6067713