### PR TITLE
Update PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,50 +8,65 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  build_wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install cibuildwheel setuptools_scm
+
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  publish:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade pip
           pip install build setuptools_scm
-
-      - name: Get package name
-        run: |
-          PACKAGE_NAME=$(python -c 'from setup.package_info import PACKAGE_NAME; print(PACKAGE_NAME)' || echo "default-package-name")
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
-
-      - name: Build package
-        run: python -m build
-
-      - name: Get wheel file name
-        id: get_wheel
-        run: |
-          WHEEL_FILE=$(ls dist/*.whl)
-          echo "WHEEL_FILE=$WHEEL_FILE" >> $GITHUB_ENV
-          echo "Found wheel: $WHEEL_FILE"
+          python -m build --sdist --outdir dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist
 
-      - name: Upload Wheel to GitHub Release
-        uses: actions/upload-release-asset@v1
+      - name: Upload wheels to GitHub Release
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.WHEEL_FILE }}
-          asset_name: "${{ env.PACKAGE_NAME }}-${{ github.event.release.tag_name }}.whl"
-          asset_content_type: application/zip
+          files: dist/**/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build wheels across OSes using `cibuildwheel`
- publish all artifacts to PyPI
- upload built wheels on release

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687811307d00832cb703242cb49574cc