### PR TITLE
Improve documentation with expanded docstrings

### DIFF
--- a/fspin/__init__.py
+++ b/fspin/__init__.py
@@ -1,3 +1,9 @@
+"""Public interface for the :mod:`fspin` package.
+
+Importing ``fspin`` makes the :class:`RateControl` class available as
+``rate`` along with the convenience helpers :func:`spin` and :func:`loop`.
+"""
+
 from .RateControl import RateControl as rate
 from .RateControl import spin
 from .RateControl import loop


### PR DESCRIPTION
## Summary
- expand module description in `RateControl`
- provide detailed docstrings for `spin`, `loop`, `RateControl` and helpers
- add a short package level docstring
- clarify parameter docs and async behavior for `spin` and `loop`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687811c99168832cbd706af2513ca434