### PR TITLE
Unify the decorator and context manager

### DIFF
--- a/example/loop_in_place.py
+++ b/example/loop_in_place.py
@@ -4,7 +4,7 @@ import time
 import asyncio
 from functools import partial
 
-from fspin import loop
+from fspin import spin
 
 # ===== Synchronous Examples =====
 
@@ -14,39 +14,39 @@ def heartbeat(prefix='main'):
 def run_sync_examples():
     print("\n===== Synchronous Examples =====\n")
 
-    # After 1 second, the loop will exist
+    # After 1 second, the spin will exit
     print("Basic usage:")
-    with loop(heartbeat, freq=5, report=True):
+    with spin(heartbeat, freq=5, report=True):
         time.sleep(1)
-        # after 1sec it will exist.
+        # after 1sec it will exit.
         # if report is true, then report shows up
     # Report is generated automatically when report=True
 
     # if you want to hand over the args
     print("\nPassing arguments:")
-    with loop(heartbeat, freq=5, report=True, prefix='my_loop'):
+    with spin(heartbeat, freq=5, report=True, prefix='my_loop'):
         time.sleep(1)
     # Report is generated automatically when report=True
 
     # or use functools
     print("\nUsing functools.partial:")
     hb = partial(heartbeat, 'my_another_loop')
-    with loop(hb, freq=5, report=True):
+    with spin(hb, freq=5, report=True):
         time.sleep(1)
     # Report is generated automatically when report=True
 
-    # Manually terminating the looping. report info accessible from lp instance.
-    print("\nManually stopping the loop:")
-    with loop(heartbeat, freq=50, report=True) as lp:
+    # Manually terminating the spinning. report info accessible from sp instance.
+    print("\nManually stopping the spin:")
+    with spin(heartbeat, freq=50, report=True) as sp:
         # Let it run for 1 s, then stop spinning manually
         time.sleep(1)
-        lp.stop_spinning()
+        sp.stop_spinning()
         print("Manually stopped after 1 s")
 
-    # Once out of the with-block, lp is still available:
-    print(f"Total iterations recorded: {len(lp.iteration_times)}")
-    print("Deviations (s):", lp.deviations)
-    # lp.get_report()
+    # Once out of the with-block, sp is still available:
+    print(f"Total iterations recorded: {len(sp.iteration_times)}")
+    print("Deviations (s):", sp.deviations)
+    # sp.get_report()
 
 # ===== Asynchronous Examples =====
 
@@ -59,9 +59,9 @@ async def run_async_examples():
 
     # Basic usage with async function
     print("Basic usage with async function:")
-    async with loop(async_heartbeat, freq=5, report=True):
+    async with spin(async_heartbeat, freq=5, report=True):
         await asyncio.sleep(1)
-        # after 1sec it will exist.
+        # after 1sec it will exit.
         # if report is true, then report shows up
     # Report is generated automatically when report=True
     # All other functions are the same as sync

--- a/fspin/RateControl.py
+++ b/fspin/RateControl.py
@@ -3,10 +3,12 @@ This module is maintained for backward compatibility.
 - RateControl class: rate_control.py
 - ReportLogger class: reporting.py
 - spin decorator: decorators.py
-- loop context manager: loop_context.py
+- spin context manager: spin_context.py
+- loop context manager: loop_context.py (deprecated)
 """
 
 from .rate_control import RateControl
 from .reporting import ReportLogger
 from .decorators import spin
-from .loop_context import loop
+from .spin_context import spin as spin_context
+from .loop_context import loop  # Keep for backward compatibility

--- a/fspin/__init__.py
+++ b/fspin/__init__.py
@@ -1,3 +1,5 @@
 from .rate_control import RateControl as rate
-from .decorators import spin
-from .loop_context import loop
+from .decorators import spin as spin_decorator  # Original decorator
+from .spin_context import spin as spin_context_manager  # New context manager
+from .loop_context import loop  # Keep for backward compatibility
+from .unified import spin  # Unified entry point that intelligently selects between decorator and context manager

--- a/fspin/decorators.py
+++ b/fspin/decorators.py
@@ -49,6 +49,9 @@ def spin(freq, condition_fn=None, report=False, thread=False, wait=True):
                     except asyncio.CancelledError:
                         # Task was cancelled, which is expected when condition is met
                         pass
+                    finally:
+                        # Ensure it's stopped after task completes
+                        rc.stop_spinning()
 
                 return rc
             return async_wrapper
@@ -56,7 +59,11 @@ def spin(freq, condition_fn=None, report=False, thread=False, wait=True):
             @wraps(func)
             def sync_wrapper(*args, **kwargs):
                 rc = RateControl(freq, is_coroutine=False, report=report, thread=thread)
-                rc.start_spinning(func, condition_fn, *args, **kwargs)
+                try:
+                    rc.start_spinning(func, condition_fn, *args, **kwargs)
+                finally:
+                    rc.stop_spinning()
                 return rc
+
             return sync_wrapper
     return decorator

--- a/fspin/loop_context.py
+++ b/fspin/loop_context.py
@@ -1,9 +1,13 @@
 import asyncio
-from .rate_control import RateControl
+import warnings
+from .spin_context import spin
 
-class loop:
+# For backward compatibility
+class loop(spin):
     """
     Context manager for running a function at a specified frequency.
+
+    DEPRECATED: Use 'spin' instead. This class is maintained for backward compatibility.
 
     This context manager creates a RateControl instance and starts spinning the provided
     function at the specified frequency. When the context is exited, the spinning is
@@ -13,67 +17,11 @@ class loop:
     configures itself accordingly. Use with the appropriate syntax:
     - For synchronous functions: `with loop(func, freq) as lp:`
     - For asynchronous functions: `async with loop(func, freq) as lp:`
-
-    Args:
-        func (callable): The function to execute at the specified frequency.
-        freq (float): Target frequency in Hz (cycles per second).
-        condition_fn (callable, optional): Function returning True to continue spinning.
-            Defaults to None (always continue).
-        report (bool, optional): Enable performance reporting. Defaults to False.
-        thread (bool, optional): Use threading for synchronous functions. Defaults to True.
-        **kwargs: Keyword arguments to pass to func.
-
-    Yields:
-        RateControl: The RateControl instance managing the spinning.
-
-    Example:
-        >>> def heartbeat():
-        ...     print("Beat")
-        >>> with loop(heartbeat, freq=5, report=True) as lp:
-        ...     time.sleep(1)  # Let it run for 1 second
-        >>> # Automatically stops spinning when exiting the context
-
-        >>> async def async_heartbeat():
-        ...     print("Async Beat")
-        ...     await asyncio.sleep(0)
-        >>> async with loop(async_heartbeat, freq=5, report=True) as lp:
-        ...     await asyncio.sleep(1)  # Let it run for 1 second
-        >>> # Automatically stops spinning when exiting the context
-
-        >>> async def background_task():
-        ...     print("Running in the background")
-        >>> async with loop(background_task, freq=5) as lp:
-        ...     print("Continuing with other work while task runs in background")
-        ...     await asyncio.sleep(1)  # Do other work
-        >>> # Task is stopped when exiting the context
     """
     def __init__(self, func, freq, *, condition_fn=None, report=False, thread=True, **kwargs):
-        # Automatically detect if the function is a coroutine
-        is_coroutine = asyncio.iscoroutinefunction(func)
-
-        self.rc = RateControl(freq, is_coroutine=is_coroutine, report=report, thread=thread)
-        self.func = func
-        self.condition_fn = condition_fn
-        self.kwargs = kwargs
-        self.is_coroutine = is_coroutine
-
-    def __enter__(self):
-        if self.is_coroutine:
-            raise TypeError("For coroutine functions, use 'async with loop(...)' instead.")
-
-        self.rc.start_spinning(self.func, self.condition_fn, **self.kwargs)
-        return self.rc
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.rc.stop_spinning()
-
-    async def __aenter__(self):
-        if not self.is_coroutine:
-            raise TypeError("For regular functions, use 'with loop(...)' instead.")
-
-        # Store the task and start it in fire-and-forget mode
-        self._task = await self.rc.start_spinning_async(self.func, self.condition_fn, **self.kwargs)
-        return self.rc
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.rc.stop_spinning()
+        warnings.warn(
+            "The 'loop' context manager is deprecated. Use 'spin' instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        super().__init__(func, freq, condition_fn=condition_fn, report=report, thread=thread, **kwargs)

--- a/fspin/spin_context.py
+++ b/fspin/spin_context.py
@@ -1,0 +1,79 @@
+import asyncio
+from .rate_control import RateControl
+
+class spin:
+    """
+    Context manager for running a function at a specified frequency.
+
+    This context manager creates a RateControl instance and starts spinning the provided
+    function at the specified frequency. When the context is exited, the spinning is
+    automatically stopped.
+
+    This context manager automatically detects if the function is a coroutine and
+    configures itself accordingly. Use with the appropriate syntax:
+    - For synchronous functions: `with spin(func, freq) as sp:`
+    - For asynchronous functions: `async with spin(func, freq) as sp:`
+
+    Args:
+        func (callable): The function to execute at the specified frequency.
+        freq (float): Target frequency in Hz (cycles per second).
+        condition_fn (callable, optional): Function returning True to continue spinning.
+            Defaults to None (always continue).
+        report (bool, optional): Enable performance reporting. Defaults to False.
+        thread (bool, optional): Use threading for synchronous functions. Defaults to True.
+        **kwargs: Keyword arguments to pass to func.
+
+    Yields:
+        RateControl: The RateControl instance managing the spinning.
+
+    Example:
+        >>> def heartbeat():
+        ...     print("Beat")
+        >>> with spin(heartbeat, freq=5, report=True) as sp:
+        ...     time.sleep(1)  # Let it run for 1 second
+        >>> # Automatically stops spinning when exiting the context
+
+        >>> async def async_heartbeat():
+        ...     print("Async Beat")
+        ...     await asyncio.sleep(0)
+        >>> async with spin(async_heartbeat, freq=5, report=True) as sp:
+        ...     await asyncio.sleep(1)  # Let it run for 1 second
+        >>> # Automatically stops spinning when exiting the context
+
+        >>> async def background_task():
+        ...     print("Running in the background")
+        >>> async with spin(background_task, freq=5) as sp:
+        ...     print("Continuing with other work while task runs in background")
+        ...     await asyncio.sleep(1)  # Do other work
+        >>> # Task is stopped when exiting the context
+    """
+    def __init__(self, func, freq, *, condition_fn=None, report=False, thread=True, **kwargs):
+        # Automatically detect if the function is a coroutine
+        is_coroutine = asyncio.iscoroutinefunction(func)
+
+        self.rc = RateControl(freq, is_coroutine=is_coroutine, report=report, thread=thread)
+        self.func = func
+        self.condition_fn = condition_fn
+        self.kwargs = kwargs
+        self.is_coroutine = is_coroutine
+
+    def __enter__(self):
+        if self.is_coroutine:
+            raise TypeError("For coroutine functions, use 'async with spin(...)' instead.")
+
+        self.rc.start_spinning(self.func, self.condition_fn, **self.kwargs)
+        return self.rc
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.rc.stop_spinning()
+
+    async def __aenter__(self):
+        if not self.is_coroutine:
+            raise TypeError("For regular functions, use 'with spin(...)' instead.")
+
+        # Store the task and start it in fire-and-forget mode
+        self._task = await self.rc.start_spinning_async(self.func, self.condition_fn, **self.kwargs)
+        return self.rc
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.rc.stop_spinning()

--- a/fspin/unified.py
+++ b/fspin/unified.py
@@ -1,0 +1,42 @@
+import inspect
+import asyncio
+from functools import wraps
+from .rate_control import RateControl
+from .decorators import spin as spin_decorator
+from .spin_context import spin as spin_context_manager
+
+class UnifiedSpin:
+    """
+    Unified entry point for fspin that intelligently selects between decorator,
+    context manager, or direct class usage based on how it's called.
+
+    Usage:
+        # As a decorator
+        @spin(freq=10)
+        def my_function():
+            pass
+
+        # As a context manager
+        with spin(my_function, freq=10):
+            # Code to run while function is spinning
+            pass
+    """
+
+    def __call__(self, *args, **kwargs):
+        # Determine how spin is being called
+
+        # Case 1: Called with no positional args or first arg is a number (freq)
+        # This is decorator usage: @spin(freq=10)
+        if not args or isinstance(args[0], (int, float)):
+            return spin_decorator(*args, **kwargs)
+
+        # Case 2: First arg is a callable (function or coroutine)
+        # This is context manager usage: with spin(func, freq=10)
+        if callable(args[0]):
+            return spin_context_manager(*args, **kwargs)
+
+        # Default case - should not reach here
+        raise TypeError("Invalid usage of spin. Use as decorator (@spin) or context manager (with spin()).")
+
+# Create a singleton instance
+spin = UnifiedSpin()

--- a/readme.md
+++ b/readme.md
@@ -37,13 +37,13 @@ function_to_loop() # this will be blocking, and start looping
 ### with Context-Manager
 ```python
 import time
-from fspin import loop
+from fspin import spin
 
 def heartbeat():
     print(f"Heartbeat at {time.strftime('%H:%M:%S')}")
 
 # Runs in background thread at 2Hz, auto-stops on exit, prints report
-with loop(heartbeat, freq=2, report=True, thread=True):
+with spin(heartbeat, freq=2, report=True, thread=True):
     time.sleep(5)  # keep the block alive for 5s
     print("exiting the loop")
 # automatically exit the loop after 5 sec

--- a/tests/test_ratecontrol.py
+++ b/tests/test_ratecontrol.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 import sys
 import os
+import re
 
 from fspin.reporting import ReportLogger
 from fspin.rate_control import RateControl
@@ -376,7 +377,7 @@ def test_loop_type_error_with_coroutine():
         await asyncio.sleep(0)
 
     # This should raise TypeError because async_function is a coroutine
-    with pytest.raises(TypeError, match="For coroutine functions, use 'async with loop"):
+    with pytest.raises(TypeError, match=re.escape("For coroutine functions, use 'async with spin(...)' instead.")):
         with loop(async_function, freq=100):
             time.sleep(0.01)
 
@@ -710,6 +711,6 @@ async def test_async_loop_with_regular_function():
         pass
 
     # This should raise a TypeError
-    with pytest.raises(TypeError, match="For regular functions, use 'with loop"):
+    with pytest.raises(TypeError, match="For regular functions, use 'with spin(...)"):
         async with loop(work, freq=100) as _:
             await asyncio.sleep(0.01)

--- a/tests/test_spin_context.py
+++ b/tests/test_spin_context.py
@@ -1,0 +1,103 @@
+import time
+import asyncio
+import pytest
+from fspin import spin, loop, rate
+
+def test_spin_decorator():
+    """Test that the spin decorator works correctly."""
+    counter = {'count': 0}
+    
+    def condition():
+        return counter['count'] < 3
+    
+    @spin(freq=10, condition_fn=condition, report=True, thread=False)
+    def test_function():
+        counter['count'] += 1
+        time.sleep(0.01)
+    
+    # Call the decorated function
+    rc = test_function()
+    assert counter['count'] == 3
+    assert rc.status == "stopped"
+
+def test_spin_context_manager():
+    """Test that the spin context manager works correctly."""
+    counter = {'count': 0}
+    
+    def test_function():
+        counter['count'] += 1
+        time.sleep(0.01)
+    
+    # Use the context manager
+    with spin(test_function, freq=10, report=True) as sp:
+        time.sleep(0.25)  # Should allow for ~2-3 iterations
+    
+    assert counter['count'] >= 2
+    assert sp.status == "stopped"
+
+def test_loop_context_manager_deprecated():
+    """Test that the loop context manager works but is deprecated."""
+    counter = {'count': 0}
+    
+    def test_function():
+        counter['count'] += 1
+        time.sleep(0.01)
+    
+    # Use the deprecated context manager
+    with pytest.warns(DeprecationWarning):
+        with loop(test_function, freq=10, report=True) as lp:
+            time.sleep(0.25)  # Should allow for ~2-3 iterations
+    
+    assert counter['count'] >= 2
+    assert lp.status == "stopped"
+
+@pytest.mark.asyncio
+async def test_async_spin_decorator():
+    """Test that the spin decorator works with async functions."""
+    counter = {'count': 0}
+    
+    def condition():
+        return counter['count'] < 3
+    
+    @spin(freq=10, condition_fn=condition, report=True)
+    async def test_function():
+        counter['count'] += 1
+        await asyncio.sleep(0.01)
+    
+    # Call the decorated function
+    rc = await test_function()
+    assert counter['count'] == 3
+    assert rc.status == "stopped"
+
+@pytest.mark.asyncio
+async def test_async_spin_context_manager():
+    """Test that the spin context manager works with async functions."""
+    counter = {'count': 0}
+    
+    async def test_function():
+        counter['count'] += 1
+        await asyncio.sleep(0.01)
+    
+    # Use the context manager
+    async with spin(test_function, freq=10, report=True) as sp:
+        await asyncio.sleep(0.25)  # Should allow for ~2-3 iterations
+    
+    assert counter['count'] >= 2
+    assert sp.status == "stopped"
+
+@pytest.mark.asyncio
+async def test_async_loop_context_manager_deprecated():
+    """Test that the loop context manager works with async functions but is deprecated."""
+    counter = {'count': 0}
+    
+    async def test_function():
+        counter['count'] += 1
+        await asyncio.sleep(0.01)
+    
+    # Use the deprecated context manager
+    with pytest.warns(DeprecationWarning):
+        async with loop(test_function, freq=10, report=True) as lp:
+            await asyncio.sleep(0.25)  # Should allow for ~2-3 iterations
+    
+    assert counter['count'] >= 2
+    assert lp.status == "stopped"


### PR DESCRIPTION
This pull request introduces a significant refactor to the `fspin` library, replacing the `loop` context manager with a new `spin` context manager while maintaining backward compatibility. A unified entry point for `spin` has also been added to intelligently handle usage as a decorator or context manager. The changes include updates to the library's core functionality, deprecation handling, and extensive testing improvements.

### Core Functionality Updates:
* Introduced the `spin` context manager to replace `loop`, providing a streamlined and improved interface for running functions at a specified frequency. (`fspin/spin_context.py`, [fspin/spin_context.pyR1-R79](diffhunk://#diff-81bd968cc25663e5094f9fcd6b8fc9110b619a8340b0fb8a98d51b3707a49c5cR1-R79))
* Deprecated the `loop` context manager, which now inherits from `spin` and issues a `DeprecationWarning` when used. (`fspin/loop_context.py`, [[1]](diffhunk://#diff-e3a0e80cbc5bf74deb9db9bfd0e82fb754a93ed39a137ac56ade1b6eb16e1d6aL2-R11) [[2]](diffhunk://#diff-e3a0e80cbc5bf74deb9db9bfd0e82fb754a93ed39a137ac56ade1b6eb16e1d6aL16-R27)
* Added a unified entry point `spin` that intelligently switches between decorator and context manager usage. (`fspin/unified.py`, [fspin/unified.pyR1-R42](diffhunk://#diff-71dc53457de61fdaeff76f2648e9ac2aaa3b2c59a7c2a53ec12a158beb4bbbb0R1-R42))

### Codebase Adjustments:
* Updated all references to `loop` in examples, documentation, and tests to use `spin`. (`example/loop_in_place.py`, [[1]](diffhunk://#diff-e6b27fa2f01e0dcfbcbb89b0295abb067eb39949ba92024d27ab95a06b5e038aL7-R7) [[2]](diffhunk://#diff-e6b27fa2f01e0dcfbcbb89b0295abb067eb39949ba92024d27ab95a06b5e038aL17-R49) [[3]](diffhunk://#diff-e6b27fa2f01e0dcfbcbb89b0295abb067eb39949ba92024d27ab95a06b5e038aL62-R64); `readme.md`, [[4]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L40-R46)
* Modified `RateControl` usage in the `spin` decorator to ensure the spinning process is stopped properly in both synchronous and asynchronous contexts. (`fspin/decorators.py`, [fspin/decorators.pyR52-R67](diffhunk://#diff-537f407aae7aedc6af3e8772ec233b0508768ab7e85694e910f740735ba41b74R52-R67))

### Backward Compatibility:
* Retained `loop` in the library for backward compatibility, with appropriate warnings and minimal maintenance. (`fspin/RateControl.py`, [[1]](diffhunk://#diff-c7284cd8f1907c5d69b623a7d657350371a5023c99bb5479b9cd35a4d382726dL6-R14); `fspin/__init__.py`, [[2]](diffhunk://#diff-af9e628b762c5e1fdcec1460767f70b8c2bbe1e8ba95db388c132382524457ffL2-R5)

### Testing Enhancements:
* Added comprehensive tests for the new `spin` context manager and decorator, including both synchronous and asynchronous use cases. (`tests/test_spin_context.py`, [tests/test_spin_context.pyR1-R103](diffhunk://#diff-eb13192f716ded4b86574b56bcc54b05878bfd1d42204c58e891dcff263406e8R1-R103))
* Updated existing tests to reflect the deprecation of `loop` and ensure compatibility with `spin`. (`tests/test_ratecontrol.py`, [[1]](diffhunk://#diff-92b99d7d17114be627ead7d1d19552f7e6bfed82a3aba05736ab70db36673552L379-R380) [[2]](diffhunk://#diff-92b99d7d17114be627ead7d1d19552f7e6bfed82a3aba05736ab70db36673552L713-R714)

These changes modernize the library, improve usability, and ensure a smooth transition for existing users while maintaining backward compatibility.