### PR TITLE
Update: README to replace 'loop' with 'spin' context manager references

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -8,9 +8,9 @@ This directory contains simple usage examples for **fspin**. Each example demons
 | `sync_manual.py`       | Use `rate` directly with a synchronous function.            |
 | `async_decorator.py`   | Run an async function with the `@spin` decorator, showing both blocking and non-blocking patterns. |
 | `async_manual.py`      | Use `rate` directly with an async function, showing both blocking and non-blocking patterns. |
-| `async_fire_and_forget.py` | Demonstrate the fire-and-forget pattern with both the `@spin` decorator and the `loop` context manager. |
-| `async_loop_context.py`| Use the `loop` context manager with async functions, showing auto-detection of coroutines and both blocking and non-blocking patterns. |
-| `loop_in_place.py`     | Use context manager `with loop(...):`.                      |
+| `async_fire_and_forget.py` | Demonstrate the fire-and-forget pattern with both the `@spin` decorator and the `spin` context manager. |
+| `async_loop_context.py`| Use the `spin` context manager with async functions, showing auto-detection of coroutines and both blocking and non-blocking patterns. |
+| `loop_in_place.py`     | Use context manager `with spin(...):`.                      |
 | `dynamic_frequency.py` | Change the loop frequency at runtime.                       |
 
 Run any example with `python <file>` to see the behaviour.
@@ -37,21 +37,21 @@ You can copy‑paste this section into a large language model to get help or qui
 - `thread` – if `True`, synchronous functions run in a background thread so the call immediately returns.
 - `wait` – for async functions, if `True` (default), awaits the task to completion (blocking); if `False`, returns immediately (fire-and-forget).
 
-### `loop`
+### `spin` (Context Manager)
 
 ```python
 # For synchronous functions
-with loop(func, freq, condition_fn=None, report=False, thread=True, **kwargs) as rc:
+with spin(func, freq, condition_fn=None, report=False, thread=True, **kwargs) as rc:
     ...
 
 # For asynchronous functions
-async with loop(async_func, freq, condition_fn=None, report=False, **kwargs) as rc:
+async with spin(async_func, freq, condition_fn=None, report=False, **kwargs) as rc:
     ...
 ```
 
 - Context manager that starts `func` looping on entry and automatically stops on exit.
 - Automatically detects if the function is a coroutine and uses the appropriate context manager.
-- Provides the same options as `spin` but runs in the background for synchronous functions.
+- For synchronous functions, runs in the background when `thread=True` (default).
 - The returned object `rc` is an instance of `RateControl` which can be queried or manually stopped.
 
 ### `rate` / `RateControl`

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A small utility for running Python functions or coroutines at a fixed rate. It o
 ![Coverage](coverage.svg)
 
 ## Features
-- `loop()` context manager for scoped background loops
+- `spin()` context manager for scoped background loops
 - `@spin` decorator to easily loop sync or async functions
 - `rate` / `RateControl` class for manual control
 - Adjustable frequency at runtime
@@ -72,7 +72,7 @@ rc.stop_spinning()
 ### Async with Fire-and-Forget Pattern
 ```python
 import asyncio
-from fspin import spin, loop
+from fspin import spin
 
 # Using the @spin decorator with wait=False for fire-and-forget
 @spin(freq=10, report=True, wait=False)
@@ -87,13 +87,13 @@ async def main():
     await asyncio.sleep(1)  # Do other work
     rc.stop_spinning()  # Stop the background task when done
 
-# Using the loop context manager with wait=False
+# Using the spin context manager with wait=False
 async def another_task():
     print("Another background task")
     await asyncio.sleep(0.1)
 
 async def another_main():
-    async with loop(another_task, freq=10, report=True) as lp:
+    async with spin(another_task, freq=10, report=True) as sp:
         print("Context manager returned immediately")
         await asyncio.sleep(1)  # Do other work
     # Task is stopped when exiting the context


### PR DESCRIPTION
This pull request updates the documentation to consistently use the term `spin` instead of `loop` for the context manager throughout the project. This change clarifies the API and ensures that usage examples and explanations match the current implementation.

**Documentation consistency and terminology updates:**

* Updated all references of the `loop` context manager to `spin` in both `readme.md` and `example/README.md`, including code examples and feature lists. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L11-R11) [[2]](diffhunk://#diff-bc501e6e1e9420017b2d954e834fd8c3afb7daf9e2eb780c46c491099a7c2f0eL11-R13)
* Revised example descriptions in `example/README.md` to mention the `spin` context manager instead of `loop`, and updated usage patterns accordingly.
* Updated the API documentation section in `example/README.md` to describe `spin` as the context manager, with revised code samples for both synchronous and asynchronous usage.
* Adjusted fire-and-forget usage examples to use `spin` instead of `loop` for context management in `readme.md`. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L75-R75) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L90-R96)