### PR TITLE
Wait

### DIFF
--- a/example/async_decorator.py
+++ b/example/async_decorator.py
@@ -16,8 +16,8 @@ def condition():
     # Continue until we have 5 iterations
     return counter['count'] < 5
 
-# Blocking version (wait=True, default)
-@spin(freq=2, condition_fn=condition, report=True)
+# Blocking version (wait=True)
+@spin(freq=2, condition_fn=condition, report=True, wait=True)
 async def blocking_loop():
     counter['count'] += 1
     print(f"Blocking decorator tick {counter['count']} at {time.strftime('%H:%M:%S')}")
@@ -31,7 +31,7 @@ async def non_blocking_loop():
     await asyncio.sleep(0.1)  # Simulate some async work
 
 async def run_blocking():
-    print("\n--- Blocking mode (wait=True, default) ---")
+    print("\n--- Blocking mode (wait=True) ---")
     # This will wait until all iterations are complete
     rc = await blocking_loop()
 

--- a/example/async_manual.py
+++ b/example/async_manual.py
@@ -22,14 +22,14 @@ async def main_loop():
     await asyncio.sleep(0.1)  # Simulate some async work
 
 async def run_blocking():
-    print("\n--- Blocking mode (wait=True, default) ---")
+    print("\n--- Blocking mode (wait=True) ---")
 
     # Create a RateControl instance for async functions
     rc = rate(freq=2, is_coroutine=True, report=True)
 
-    # Start spinning with the default wait=True (blocking)
+    # Start spinning with wait=True (blocking)
     # This will wait until all iterations are complete
-    await rc.start_spinning_async_wrapper(main_loop, condition)
+    await rc.start_spinning_async_wrapper(main_loop, condition, wait=True)
 
     print(f"Completed {counter['count']} iterations")
     print("This line is executed after all iterations are complete")

--- a/fspin/decorators.py
+++ b/fspin/decorators.py
@@ -2,7 +2,7 @@ import asyncio
 from functools import wraps
 from .rate_control import RateControl
 
-def spin(freq, condition_fn=None, report=False, thread=False, wait=None):
+def spin(freq, condition_fn=None, report=False, thread=False, wait=False):
     """
     Decorator to run the decorated function at a specified frequency (Hz).
 
@@ -16,11 +16,11 @@ def spin(freq, condition_fn=None, report=False, thread=False, wait=None):
             Defaults to None (always continue).
         report (bool, optional): Enable performance reporting. Defaults to False.
         thread (bool, optional): Use threading for synchronous functions. Defaults to False.
-        wait (bool | None, optional):
+        wait (bool, optional):
             - For async functions: whether to await the task (blocking) or return immediately
-              (fire-and-forget). Defaults to True (blocking) when not provided.
+              (fire-and-forget). Defaults to False (fire-and-forget).
             - For sync functions with thread=True: whether to join the thread before returning
-              (i.e., block until completion). Defaults to False (fire-and-forget) when not provided.
+              (i.e., block until completion). Defaults to False (fire-and-forget).
 
     Returns:
         callable: A decorated function that will run at the specified frequency.
@@ -46,9 +46,7 @@ def spin(freq, condition_fn=None, report=False, thread=False, wait=None):
                 rc = RateControl(freq, is_coroutine=True, report=report, thread=thread)
                 task = await rc.start_spinning_async(func, condition_fn, *args, **kwargs)
 
-                # Default wait to True for async if not explicitly provided
-                _wait = True if wait is None else wait
-                if _wait:
+                if wait:
                     try:
                         await task
                     except asyncio.CancelledError:
@@ -64,12 +62,10 @@ def spin(freq, condition_fn=None, report=False, thread=False, wait=None):
             @wraps(func)
             def sync_wrapper(*args, **kwargs):
                 rc = RateControl(freq, is_coroutine=False, report=report, thread=thread)
-                # Default wait to False for sync if not explicitly provided
-                _wait = False if wait is None else wait
-                # Forward wait for sync threaded mode; if _wait=True it will join before returning
-                rc.start_spinning(func, condition_fn, *args, wait=_wait, **kwargs)
+                # Forward wait for sync threaded mode; if wait=True it will join before returning
+                rc.start_spinning(func, condition_fn, *args, wait=wait, **kwargs)
                 # If we waited (thread join or blocking mode), ensure stopped; otherwise leave running
-                if _wait or not thread:
+                if wait or not thread:
                     rc.stop_spinning()
                 return rc
 

--- a/fspin/rate_control.py
+++ b/fspin/rate_control.py
@@ -354,7 +354,7 @@ class RateControl:
         self._task = asyncio.create_task(self.spin_async(func, condition_fn, *args, **kwargs))
         return self._task
 
-    async def start_spinning_async_wrapper(self, func, condition_fn=None, *, wait=True, **kwargs):
+    async def start_spinning_async_wrapper(self, func, condition_fn=None, *, wait=False, **kwargs):
         """
         Wrapper for start_spinning_async to be used with await.
 
@@ -362,7 +362,7 @@ class RateControl:
             func (callable): The coroutine function to execute at the specified frequency.
             condition_fn (callable, optional): Function returning True to continue spinning.
             wait (bool, optional): Whether to await the task (blocking) or return immediately
-                (fire-and-forget). Defaults to True (blocking).
+                (fire-and-forget). Defaults to False (fire-and-forget).
             **kwargs: Keyword arguments to pass to func.
 
         Returns:

--- a/fspin/rate_control.py
+++ b/fspin/rate_control.py
@@ -8,6 +8,8 @@ from statistics import mean, stdev
 import traceback
 from contextlib import contextmanager
 import logging
+import os
+import json
 from .reporting import ReportLogger
 
 # Library logger
@@ -312,18 +314,29 @@ class RateControl:
             condition_fn (callable, optional): Function returning True to continue spinning.
             *args: Positional arguments to pass to func.
             **kwargs: Keyword arguments to pass to func.
+                Recognized keyword-only options:
+                - wait (bool): If thread=True and wait=True, join the thread before returning.
+                  Defaults to False for backward compatibility.
 
         Returns:
             threading.Thread or None: The thread object if thread=True, None otherwise.
         """
+        # Backward-compatible way to accept a keyword-only 'wait' without changing signature
+        wait = kwargs.pop("wait", False)
+
         if self.thread:
             self._thread = threading.Thread(
                 target=self.spin_sync, args=(func, condition_fn) + args, kwargs=kwargs)
             self._thread.daemon = True
             self._thread.start()
+            if wait:
+                # Block until the spinning thread completes
+                self._thread.join()
             return self._thread
         else:
+            # Blocking mode: run in the current thread
             self.spin_sync(func, condition_fn, *args, **kwargs)
+            return None
 
     async def start_spinning_async(self, func, condition_fn, *args, **kwargs):
         """
@@ -401,7 +414,10 @@ class RateControl:
                 self._task.cancel()
         else:
             if self._thread:
-                self._thread.join()
+                # Avoid deadlock if stop_spinning is called from within the worker thread
+                current = threading.current_thread()
+                if self._thread.is_alive() and current is not self._thread:
+                    self._thread.join()
         if self._own_loop is not None:
             self._own_loop.close()
             self._own_loop = None

--- a/fspin/spin_context.py
+++ b/fspin/spin_context.py
@@ -47,7 +47,7 @@ class spin:
         ...     await asyncio.sleep(1)  # Do other work
         >>> # Task is stopped when exiting the context
     """
-    def __init__(self, func, freq, *, condition_fn=None, report=False, thread=True, **kwargs):
+    def __init__(self, func, freq, *, condition_fn=None, report=False, thread=True, wait=False, **kwargs):
         # Automatically detect if the function is a coroutine
         is_coroutine = asyncio.iscoroutinefunction(func)
 
@@ -56,12 +56,13 @@ class spin:
         self.condition_fn = condition_fn
         self.kwargs = kwargs
         self.is_coroutine = is_coroutine
+        self.wait = wait
 
     def __enter__(self):
         if self.is_coroutine:
             raise TypeError("For coroutine functions, use 'async with spin(...)' instead.")
 
-        self.rc.start_spinning(self.func, self.condition_fn, **self.kwargs)
+        self.rc.start_spinning(self.func, self.condition_fn, wait=self.wait, **self.kwargs)
         return self.rc
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/fspin_cheatsheet.md
+++ b/fspin_cheatsheet.md
@@ -23,7 +23,7 @@ The primary way to use fspin is through the `@spin` decorator, which automatical
 ```python
 from fspin import spin
 
-@spin(freq=10, condition_fn=None, report=False, thread=False, wait=True)
+@spin(freq=10, condition_fn=None, report=False, thread=False, wait=False)
 def my_function():
     # This will run at 10Hz (10 times per second)
     print("Hello")
@@ -79,14 +79,14 @@ rc.stop_spinning()
 ### `@spin` Decorator
 
 ```python
-@spin(freq, condition_fn=None, report=False, thread=False, wait=True)
+@spin(freq, condition_fn=None, report=False, thread=False, wait=False)
 ```
 
 - `freq` (float): Target frequency in Hz (cycles per second)
 - `condition_fn` (callable, optional): Function returning True to continue spinning, False to stop
 - `report` (bool): When True, performance statistics are recorded and printed
 - `thread` (bool): For sync functions, if True, runs in a background thread
-- `wait` (bool): For async functions, if True (default), awaits completion; if False, returns immediately
+- `wait` (bool): For async functions, if True, awaits completion; if False (default), returns immediately. For sync threaded functions, if True, joins the thread; default is False (fire-and-forget).
 
 Returns:
 - The decorated function returns a `RateControl` instance that can be used to control the spinning process

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,9 @@
 # pytest.ini
 [pytest]
+# Enforce timeouts on all tests to avoid infinite hangs
+# Use thread-based timeout method for Windows compatibility
+# Default timeout in seconds for each test
+# You can override per-test by using @pytest.mark.timeout(x)
+addopts = -q
+timeout = 5
+timeout_method = thread

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.0
+pytest-timeout>=2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pytest>=7.0
-pytest-timeout>=2.3.1

--- a/tests/test_ratecontrol.py
+++ b/tests/test_ratecontrol.py
@@ -97,7 +97,7 @@ async def test_spin_async_counts():
         # Continue until we have at least 2 calls
         return len(calls) < 2
 
-    @spin(freq=100, condition_fn=condition, report=True)
+    @spin(freq=100, condition_fn=condition, report=True, wait=True)
     async def awork():
         calls.append(time.perf_counter())
         await asyncio.sleep(0.01)  # Small delay to ensure the function runs
@@ -204,7 +204,7 @@ async def test_spin_async_exception_handling(caplog):
     # We'll check for the exception message in the logs instead of using pytest.warns
     with caplog.at_level(logging.INFO, logger="root"):
         try:
-            await rc.start_spinning_async_wrapper(awork, cond)
+            await rc.start_spinning_async_wrapper(awork, cond, wait=True)
         except Exception as e:
             # If an exception is raised, that's fine - we're testing exception handling
             print(f"Exception raised: {e}")
@@ -355,7 +355,7 @@ async def test_automatic_report_generation_async():
         await asyncio.sleep(0.01)  # Small delay to ensure the function runs
 
     rc = RateControl(freq=100, is_coroutine=True, report=True)
-    await rc.start_spinning_async_wrapper(awork, condition)
+    await rc.start_spinning_async_wrapper(awork, condition, wait=True)
 
     # Verify that the function was called at least once
     assert len(calls) > 0, "Function was not called"

--- a/tests/test_spin_context.py
+++ b/tests/test_spin_context.py
@@ -59,7 +59,7 @@ async def test_async_spin_decorator():
     def condition():
         return counter['count'] < 3
     
-    @spin(freq=10, condition_fn=condition, report=True)
+    @spin(freq=10, condition_fn=condition, report=True, wait=True)
     async def test_function():
         counter['count'] += 1
         await asyncio.sleep(0.01)

--- a/tests/test_spin_context_sync_wait.py
+++ b/tests/test_spin_context_sync_wait.py
@@ -1,0 +1,24 @@
+import time
+from fspin.spin_context import spin
+
+
+def test_spin_context_sync_waitable():
+    calls = []
+
+    def condition():
+        return len(calls) < 5
+
+    def work():
+        calls.append(time.perf_counter())
+        time.sleep(0.005)
+
+    start = time.perf_counter()
+    with spin(work, freq=100, condition_fn=condition, thread=True, wait=True) as rc:
+        # If wait=True, by the time we enter the body, the loop should be done
+        inside_elapsed = time.perf_counter() - start
+        assert inside_elapsed >= 0.02, "Context manager should have waited before entering body"
+        assert len(calls) == 5
+        assert rc._thread is not None
+        assert not rc._thread.is_alive()
+    # After exit, still done
+    assert len(calls) == 5

--- a/tests/test_sync_wait_join.py
+++ b/tests/test_sync_wait_join.py
@@ -1,0 +1,32 @@
+import time
+from fspin.rate_control import RateControl
+
+
+def test_sync_threaded_wait_joins_thread():
+    calls = []
+
+    def condition():
+        return len(calls) < 5
+
+    def work():
+        calls.append(time.perf_counter())
+        # simulate some work taking less than the loop duration
+        time.sleep(0.005)
+
+    rc = RateControl(100, is_coroutine=False, report=True, thread=True)
+
+    # When wait=True and threaded=True, this should block until the thread completes
+    t = rc.start_spinning_sync(work, condition, wait=True)
+
+    # After returning, the background thread should have completed
+    assert t is not None, "Expected a thread object to be returned"
+    assert not t.is_alive(), "Thread should have finished when wait=True"
+
+    # All iterations should have been executed
+    assert len(calls) == 5, f"Expected 5 calls, got {len(calls)}"
+
+    # Finalize should have been called
+    assert rc.end_time is not None, "Expected end_time to be set after completion"
+
+    # Mode should indicate threaded sync
+    assert rc.mode == "sync-threaded", "Incorrect mode detected for threaded sync"

--- a/tests/test_sync_waitable_decorator.py
+++ b/tests/test_sync_waitable_decorator.py
@@ -1,0 +1,27 @@
+import time
+from fspin.decorators import spin
+
+
+def test_sync_decorator_threaded_wait_joins_thread():
+    calls = []
+
+    def condition():
+        return len(calls) < 5
+
+    @spin(freq=100, condition_fn=condition, thread=True, wait=True)
+    def work():
+        calls.append(time.perf_counter())
+        time.sleep(0.005)
+
+    start = time.perf_counter()
+    rc = work()
+    elapsed = time.perf_counter() - start
+
+    # Should have blocked roughly for the loop duration * iterations
+    assert elapsed >= 0.02, f"Expected blocking behavior, elapsed={elapsed:.3f}s"
+
+    assert len(calls) == 5
+    # Thread should have finished if it existed
+    # In blocking mode (thread=False), _thread may be None; but here thread=True
+    assert rc._thread is not None
+    assert not rc._thread.is_alive()


### PR DESCRIPTION
This pull request updates the `wait` parameter behavior for the `spin` decorator, context manager, and related rate control utilities to make non-blocking execution the default for both async and threaded sync functions. It also improves documentation and test coverage to reflect these changes, ensuring clearer and more predictable blocking semantics for users.

**Core API changes:**

* Changed the default value of the `wait` parameter to `False` in the `spin` decorator, context manager, and related methods, making fire-and-forget (non-blocking) the default for async and threaded sync functions. Blocking execution now requires explicitly passing `wait=True`. [[1]](diffhunk://#diff-537f407aae7aedc6af3e8772ec233b0508768ab7e85694e910f740735ba41b74L5-R5) [[2]](diffhunk://#diff-537f407aae7aedc6af3e8772ec233b0508768ab7e85694e910f740735ba41b74L19-R23) [[3]](diffhunk://#diff-81bd968cc25663e5094f9fcd6b8fc9110b619a8340b0fb8a98d51b3707a49c5cL50-R50) [[4]](diffhunk://#diff-81bd968cc25663e5094f9fcd6b8fc9110b619a8340b0fb8a98d51b3707a49c5cR59-R65) [[5]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873L344-R365)
* Updated the implementation of `RateControl.start_spinning_sync` and `RateControl.start_spinning_async_wrapper` to correctly handle the new `wait` semantics, including proper thread joining and task awaiting when `wait=True`. [[1]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873R317-R339) [[2]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873L344-R365) [[3]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873R417-R419) [[4]](diffhunk://#diff-537f407aae7aedc6af3e8772ec233b0508768ab7e85694e910f740735ba41b74L62-R68)

**Documentation updates:**

* Revised the cheatsheet and docstrings to clarify the new default behavior for the `wait` parameter and explain blocking/non-blocking modes for both async and sync threaded functions. [[1]](diffhunk://#diff-33d4438707e714e855f399babf9ac349f08b176a3a4517aa20d1f8ed640f1200L26-R26) [[2]](diffhunk://#diff-33d4438707e714e855f399babf9ac349f08b176a3a4517aa20d1f8ed640f1200L82-R89) [[3]](diffhunk://#diff-537f407aae7aedc6af3e8772ec233b0508768ab7e85694e910f740735ba41b74L19-R23)

**Test improvements:**

* Updated existing tests to explicitly pass `wait=True` where blocking behavior is required, and added new tests to verify correct blocking and thread joining for both decorator and direct usage of threaded sync functions. [[1]](diffhunk://#diff-92b99d7d17114be627ead7d1d19552f7e6bfed82a3aba05736ab70db36673552L100-R100) [[2]](diffhunk://#diff-92b99d7d17114be627ead7d1d19552f7e6bfed82a3aba05736ab70db36673552L207-R207) [[3]](diffhunk://#diff-92b99d7d17114be627ead7d1d19552f7e6bfed82a3aba05736ab70db36673552L358-R358) [[4]](diffhunk://#diff-eb13192f716ded4b86574b56bcc54b05878bfd1d42204c58e891dcff263406e8L62-R62) [[5]](diffhunk://#diff-8e08add1c40420e48cd0825f35ff3568b57b5da6501395a90eca2f5b571a7e39R1-R24) [[6]](diffhunk://#diff-1a6ca49bafc2135a7ae50904cac9312e41d15c3f2015b17ded9bb85087c574bbR1-R32) [[7]](diffhunk://#diff-92bc2283823cb25d07f8b45e28e7bdc2e98a4f6c5e0e5e41c6a20a09402959cbR1-R27)

**Other enhancements:**

* Added a default timeout to all pytest tests to prevent infinite hangs, improving CI reliability and developer experience.

**Internal codebase changes:**

* Minor refactoring and comments to support the new keyword-only `wait` parameter and ensure backward compatibility. [[1]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873R317-R339) [[2]](diffhunk://#diff-dc73774a149aa40b3293fc53e9f88b2956aafe2a58da31ee2010348bf29b6873R417-R419)